### PR TITLE
Fix link to github list of contributors etc.

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -47,7 +47,7 @@ subtitle: About
 
             <b>Citations:</b><br>
             <ol>
-                <li>Bradski G (2000) The OpenCV library. Doctor Dobb's Journal of Software Tools 25(11):120-126.</li>
+                <li>Bradski G (2000) The OpenCV library. Dr. Dobb's Journal 25(11):120-126.</li>
                 <li>Oliphant TE (2007) Python for Scientific Computing. Computing in Science & Engineering, 9, 10-20.</li>
                 <li>Hunter JD (2007) Matplotlib: A 2D graphics environment. Computing in Science & Engineering, 9, 90-95.</li>
             </ol>

--- a/pages/about.html
+++ b/pages/about.html
@@ -17,6 +17,8 @@ subtitle: About
                 <a href="http://matplotlib.org/">MatPlotLib</a> <sup>3</sup>.
                 PlantCV was created at the Donald Danforth Plant Science Center in 2014.
                 Please check back for new functions and tutorials.
+                Updates are available via twitter:
+                <a href="https://twitter.com/plantcv" class="twitter-follow-button" data-show-count="false">Follow @plantcv</a>
                 Please help us attend to your questions, bug reports, and requests
                 by posting them on our
                 <a href="https://github.com/danforthcenter/plantcv/issues">GitHub issues page</a>.

--- a/pages/about.html
+++ b/pages/about.html
@@ -38,8 +38,9 @@ subtitle: About
                 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script><br>
             </p>
 
-            <p>We encourage community contribution, see current contributor list
-              <a href="https://github.com/danforthcenter/plantcv/graphs/contributors3">here</a>
+            <p>We encourage community contribution.
+	      See our <a href="http://plantcv.readthedocs.io/en/latest/CONTRIBUTING/">guide for contributors</a>
+	      and current <a href="https://github.com/danforthcenter/plantcv/graphs/contributors">list of contributors</a>.
             </p>
 
             <b>Citations:</b><br>

--- a/pages/about.html
+++ b/pages/about.html
@@ -15,11 +15,13 @@ subtitle: About
                 <a href="http://opencv.org/">OpenCV</a> <sup>1</sup>,
                 <a href="http://www.numpy.org/">NumPy</a> <sup>2</sup>, and
                 <a href="http://matplotlib.org/">MatPlotLib</a> <sup>3</sup>.
-                PlantCV was created at the Donald Danforth Plant Science Center in 2014.
-                Please check back for new functions and tutorials.
+                The PlantCV project was started at the Donald Danforth Plant Science Center in 2014,
+                and is under active development—new functionality and tutorials are added regularly.
                 Updates are available via twitter:
                 <a href="https://twitter.com/plantcv" class="twitter-follow-button" data-show-count="false">Follow @plantcv</a>
-                Please help us attend to your questions, bug reports, and requests
+            </p>
+
+            <p>Please help us attend to your questions, bug reports, and requests
                 by posting them on our
                 <a href="https://github.com/danforthcenter/plantcv/issues">GitHub issues page</a>.
             </p>

--- a/pages/about.html
+++ b/pages/about.html
@@ -44,7 +44,7 @@ subtitle: About
 
             <b>Citations:</b><br>
             <ol>
-                <li>Bradski G (2000) The opencv library. Doctor Dobbs Journal 25(11):120-126.</li>
+                <li>Bradski G (2000) The OpenCV library. Doctor Dobb's Journal of Software Tools 25(11):120-126.</li>
                 <li>Oliphant TE (2007) Python for Scientific Computing. Computing in Science & Engineering, 9, 10-20.</li>
                 <li>Hunter JD (2007) Matplotlib: A 2D graphics environment. Computing in Science & Engineering, 9, 90-95.</li>
             </ol>

--- a/pages/about.html
+++ b/pages/about.html
@@ -17,12 +17,14 @@ subtitle: About
                 <a href="http://matplotlib.org/">MatPlotLib</a> <sup>3</sup>.
                 PlantCV was created at the Donald Danforth Plant Science Center in 2014.
                 Please check back for new functions and tutorials.
-                To more quickly serve your questions and issues please post them
-                <a href="https://github.com/nfahlgren/plantcv/issues">HERE</a>
+                Please help us attend to your questions, bug reports, and requests
+                by posting them on our
+                <a href="https://github.com/danforthcenter/plantcv/issues">GitHub issues page</a>.
             </p>
 
-            <p>If you use PlantCV please cite: paper
-                <a href="http://www.sciencedirect.com/science/article/pii/S1674205215002683">Here</a>
+            <p>If you use PlantCV, please cite
+                <a href="http://www.sciencedirect.com/science/article/pii/S1674205215002683">the initial published description</a>.
+                See also below.
             </p>
 
             <p>Core PlantCV Development Team:<br>

--- a/pages/about.html
+++ b/pages/about.html
@@ -84,6 +84,11 @@ subtitle: About
                     bioRxiv:183822. DOI: <a href="http://doi.org/10.1101/183822">10.1101/183822</a>.
                 </li>
                 <li>
+                    Veley KM, Berry JC, Fentress SJ, Schachtman DP, Baxter I, Bart RS. 2017.
+                    High-throughput profiling and analysis of plant responses over time to abiotic stress.
+                    bioRxiv:132787. DOI: <a href="https://doi.org/10.1101/132787">10.1101/132787</a>.
+                </li>
+                <li>
                     Ubbens JR, Stavness I. 2017. Deep Plant Phenomics: A deep learning platform for complex plant
                     phenotyping tasks. Frontiers in Plant Science 8:1190. DOI:
                     <a href="http://doi.org/10.3389/fpls.2017.01190">10.3389/fpls.2017.01190</a>.


### PR DESCRIPTION
Some related issues, which I will try to help with:

- [x] The first link in the main PlantCV README broke when the 'dev' branch went away. I introduced that link---sorry!
- [x] I noticed that there are two CONTRIBUTING.md files in the PlantCV source tree, one at the root and one under docs/. I gather that this was intentional (to make things work better with both ReadTheDocs and GitHub), but I think we can safely remove one, so that they do not get out of sync. The relevent [GitHub help page](https://help.github.com/articles/setting-guidelines-for-repository-contributors/) says that 'CONTRIBUTING' files under 'docs' should be automatically recognized.
I linked to the ReadTheDocs page here.
- [x] Add link to paper by Veley et al. at some point. http://www.biorxiv.org/content/early/2017/07/26/132787
- [x] Add direct link to the PlantCV twitter account at some point

The changes in wording (to avoid "HERE"-style links) is super-minor. Feel free to switch back to the previous style, if you prefer.

I did not test these changes with Jekyll or whatever, but I did not change the YAML header and the unprocessed HTML page renders fine for me, so I think the tags are OK.